### PR TITLE
Add ValueReader for ConfigValue

### DIFF
--- a/src/main/scala/net/ceedubs/ficus/readers/AllValueReaderInstances.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/AllValueReaderInstances.scala
@@ -1,7 +1,7 @@
 package net.ceedubs.ficus.readers
 
 trait AllValueReaderInstances extends AnyValReaders with StringReader with OptionReader
-    with CollectionReaders with ConfigReader with DurationReaders with ArbitraryTypeReader
-    with TryReader
+  with CollectionReaders with ConfigReader with DurationReaders with ArbitraryTypeReader
+  with TryReader with ConfigValueReader
 
 object AllValueReaderInstances extends AllValueReaderInstances

--- a/src/main/scala/net/ceedubs/ficus/readers/ConfigValueReader.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/ConfigValueReader.scala
@@ -1,0 +1,12 @@
+package net.ceedubs.ficus.readers
+
+import com.typesafe.config.ConfigValue
+import com.typesafe.config.Config
+
+trait ConfigValueReader {
+  implicit val configValueValueReader: ValueReader[ConfigValue] = new ValueReader[ConfigValue] {
+    override def read(config: Config, path: String): ConfigValue = config.getValue(path)
+  }
+}
+
+object ConfigValueReader extends ConfigValueReader

--- a/src/test/scala/net/ceedubs/ficus/readers/ConfigValueReaderSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/readers/ConfigValueReaderSpec.scala
@@ -1,0 +1,59 @@
+package net.ceedubs.ficus.readers
+
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Spec
+import com.typesafe.config.ConfigValueType
+import net.ceedubs.ficus.ConfigSerializerOps._
+
+class ConfigValueReaderSpec extends Spec with ConfigValueReader {
+  def is = s2"""
+  The ConfigValue value reader should
+    read a boolean $readBoolean
+    read an int $readInt
+    read a double $readDouble
+    read a string $readString
+    read an object $readObject
+  """
+
+  def readBoolean = prop { b: Boolean =>
+    val cfg = ConfigFactory.parseString(s"myValue = $b")
+    val read = configValueValueReader.read(cfg, "myValue")
+    read.valueType must beEqualTo(ConfigValueType.BOOLEAN)
+    read.unwrapped() must beEqualTo(b)
+  }
+
+  def readInt = prop { i: Int =>
+    val cfg = ConfigFactory.parseString(s"myValue = $i")
+    val read = configValueValueReader.read(cfg, "myValue")
+    read.valueType must beEqualTo(ConfigValueType.NUMBER)
+    read.unwrapped() must beEqualTo(int2Integer(i))
+  }
+
+  def readDouble = prop { d: Double =>
+    val cfg = ConfigFactory.parseString(s"myValue = $d")
+    val read = configValueValueReader.read(cfg, "myValue")
+    read.valueType must beEqualTo(ConfigValueType.NUMBER)
+    read.unwrapped() must beEqualTo(double2Double(d))
+  }
+
+  def readString = prop { s: String =>
+    val cfg = ConfigFactory.parseString(s"myValue = ${s.asConfigValue}")
+    val read = configValueValueReader.read(cfg, "myValue")
+    read.valueType must beEqualTo(ConfigValueType.STRING)
+    read.unwrapped() must beEqualTo(s)
+  }
+
+  def readObject = prop { i: Int =>
+    val cfg = ConfigFactory.parseString(s"myValue = { i = $i }")
+    val read = configValueValueReader.read(cfg, "myValue")
+    read.valueType must beEqualTo(ConfigValueType.OBJECT)
+    read.unwrapped() must beEqualTo(cfg.getValue("myValue").unwrapped())
+  }
+
+  def readList = prop { i: Int =>
+    val cfg = ConfigFactory.parseString(s"myValue = [ $i ]")
+    val read = configValueValueReader.read(cfg, "myValue")
+    read.valueType must beEqualTo(ConfigValueType.LIST)
+    read.unwrapped() must beEqualTo(cfg.getValue("myValue").unwrapped())
+  }
+}


### PR DESCRIPTION
Hi,

I just started using ficus and I thought it would be nifty to have a `ValueReader` for `com.typesafe.config.ConfigValue` so here it is. The underlying motivation is to read heterogeneous lists such as `[ "abc", { a = "def", b = 12 } ]` where `"abc"` is conventionally understood to be equivalent to e.g. `{ a = "abc", b = 1 }`
