### PR TITLE
hyphen-case config key support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,11 +55,12 @@ javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 /* dependencies */
 libraryDependencies <++= scalaVersion { sv =>
   Seq(
-    "org.specs2"     %% "specs2"         % "2.3.11"   % "test",
-    "org.scalacheck" %% "scalacheck"     % "1.11.3"   % "test",
-    "com.chuusai"    %% "shapeless"      % "2.0.0"    % "test",
-    "com.typesafe"   %  "config"         % "1.2.1",
-    "org.scala-lang" %  "scala-reflect"  % sv         % "provided")
+    "org.specs2"       %% "specs2"        % "2.3.11"   % "test",
+    "org.scalacheck"   %% "scalacheck"    % "1.11.3"   % "test",
+    "com.chuusai"      %% "shapeless"     % "2.0.0"    % "test",
+    "com.typesafe"     %  "config"        % "1.2.1",
+    "com.google.guava" %  "guava"         % "18.0",
+    "org.scala-lang"   %  "scala-reflect" % sv         % "provided")
 }
 
 /* you may need these repos */

--- a/src/test/scala/net/ceedubs/ficus/readers/ArbitraryTypeReaderSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/readers/ArbitraryTypeReaderSpec.scala
@@ -13,6 +13,7 @@ class ArbitraryTypeReaderSpec extends Spec { def is = s2"""
     instantiate with no apply method but a single constructor with multiple params $instantiateMultiParamConstructor
     instantiate with multiple apply methods if only one returns the correct type $multipleApply
     instantiate with primary constructor when no apply methods and multiple constructors $multipleConstructors
+    instantiate with camel case fields and hyphen case config keys $withCamelCaseFields
     use another implicit value reader for a field $withOptionField
     fall back to a default value on an apply method $fallBackToApplyMethodDefaultValue
     fall back to default values on an apply method if base key isn't in config $fallBackToApplyMethodDefaultValueNoKey
@@ -83,6 +84,14 @@ class ArbitraryTypeReaderSpec extends Spec { def is = s2"""
     val cfg = ConfigFactory.parseString(s"withMultipleConstructors { foo = ${foo.asConfigValue} }")
     val instance: ClassWithMultipleConstructors = arbitraryTypeValueReader[ClassWithMultipleConstructors].read(cfg, "withMultipleConstructors")
     instance.foo must_== foo
+  }
+
+  def withCamelCaseFields = {
+    import Ficus.{stringValueReader}
+    import HyphenCaseArbitraryTypeReader._
+    val cfg = ConfigFactory.parseString(s"withCamelCaseFields { a-camel-case-field: foo, another-camel-case-field: bar }")
+    val instance = arbitraryTypeValueReader[ClassWithCamelCaseFields].read(cfg, "withCamelCaseFields")
+    (instance.aCamelCaseField must_== "foo") and (instance.anotherCamelCaseField must_== "bar")
   }
 
   def fallBackToApplyMethodDefaultValue = {
@@ -247,8 +256,9 @@ object ArbitraryTypeReaderSpec {
   case class WithReaderInCompanion(foo: String)
 
   object WithReaderInCompanion {
-    implicit val reader: ValueReader[WithReaderInCompanion] = 
+    implicit val reader: ValueReader[WithReaderInCompanion] =
       ValueReader.relative(_ => WithReaderInCompanion("from-companion"))
   }
 
+  class ClassWithCamelCaseFields(val aCamelCaseField: String, val anotherCamelCaseField: String)
 }


### PR DESCRIPTION
This is a draft PR to implement #7 using [Guava's `CaseFormat` class](http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/base/CaseFormat.html) for the camelCase to hyphen-case conversion. 

Created separate `HyphenCaseArbitraryTypeReader` trait and object (existing `ArbitraryTypeReader` API/behavior is unchanged) that invokes a new macro that specifies a hyphen-case `NameMapper` trait implementation that gets passed down to the `extractMethodArgsFromConfig()` method. Added a test case to `ArbitraryTypeReaderSpec`.

Probably could be reorganized a bit. Please advise.