### PR TITLE
Add EnumerationReader to support Scala's Enumeration type

### DIFF
--- a/src/main/scala/net/ceedubs/ficus/Ficus.scala
+++ b/src/main/scala/net/ceedubs/ficus/Ficus.scala
@@ -6,6 +6,7 @@ import net.ceedubs.ficus.readers._
 trait FicusInstances extends AnyValReaders with StringReader with OptionReader
     with CollectionReaders with ConfigReader with DurationReaders
     with TryReader with ConfigValueReader with BigNumberReaders
+    with EnumerationReader
 
 object Ficus extends FicusInstances {
   implicit def toFicusConfig(config: Config): FicusConfig = SimpleFicusConfig(config)

--- a/src/main/scala/net/ceedubs/ficus/readers/EnumerationReader.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/EnumerationReader.scala
@@ -1,0 +1,28 @@
+package net.ceedubs.ficus.readers
+
+import com.typesafe.config.ConfigException.{BadValue, Generic}
+import com.typesafe.config.Config
+
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
+
+trait EnumerationReader {
+  implicit def enumerationValueReader[T <: Enumeration : ClassTag]: ValueReader[T#Value] = new ValueReader[T#Value] {
+    def read(config: Config, path: String): T#Value = {
+      val c = implicitly[ClassTag[T]].runtimeClass
+      val enum = Try(c.getField("MODULE$")) match {
+        case Success(m) => m.get(null).asInstanceOf[T]
+        case Failure(e) => throw new Generic("Cannot get instance of enum: " + c.getCanonicalName + "; " +
+          "make sure the enum is an object and it's not contained in a class or trait", e)
+      }
+
+      val value = config.getString(path)
+      enum.values.find(_.toString == value)
+        .getOrElse(throw new BadValue(config.origin(), path, value + " isn't a valid value for enum: " +
+          "" + c.getCanonicalName + "; allowed values: " + enum.values.mkString(", ")))
+        .asInstanceOf[T#Value]
+    }
+  }
+}
+
+object EnumerationReader extends EnumerationReader

--- a/src/test/scala/net/ceedubs/ficus/ExampleSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/ExampleSpec.scala
@@ -8,6 +8,14 @@ import net.ceedubs.ficus.readers.ValueReader
 
 case class ServiceConfig(urls: Set[String], maxConnections: Int, httpsRequired: Boolean = false)
 
+object Country extends Enumeration {
+  val DE = Value("DE")
+  val IT = Value("IT")
+  val NL = Value("NL")
+  val US = Value("US")
+  val GB = Value("GB")
+}
+
 class ExampleSpec extends Specification {
 
   // an example config snippet for us to work with
@@ -24,6 +32,7 @@ class ExampleSpec extends Specification {
       |    maxConnections = 25
       |  }
       |}
+      |countries = [DE, US, GB]
     """.stripMargin)
 
   "Ficus config" should {
@@ -37,6 +46,8 @@ class ExampleSpec extends Specification {
       analyticsServiceConfig.as[List[String]]("urls") must beEqualTo(List("localhost:8002", "localhost:8003"))
       val analyticsServiceRequiresHttps = analyticsServiceConfig.as[Option[Boolean]]("httpsRequired") getOrElse false
       analyticsServiceRequiresHttps must beFalse
+
+      config.as[Seq[Country.Value]]("countries") must be equalTo Seq(Country.DE, Country.US, Country.GB)
     }
 
     "Automagically be able to hydrate arbitrary types from config" in {

--- a/src/test/scala/net/ceedubs/ficus/readers/EnumerationReadersSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/readers/EnumerationReadersSpec.scala
@@ -1,0 +1,64 @@
+package net.ceedubs.ficus.readers
+
+import com.typesafe.config.{ConfigException, ConfigFactory}
+import net.ceedubs.ficus.Spec
+import EnumerationReadersSpec._
+
+import scala.reflect.ClassTag
+
+class EnumerationReadersSpec extends Spec with EnumerationReader { def is = s2"""
+  An enumeration value reader should
+    map a string value to its enumeration counterpart $successStringMapping
+    map a int value to its enumeration counterpart $successIntMapping
+    throw exception if value couldn't be converted to enum value $invalidMapping
+    throw exception if enumeration is contained in a class or trait $notInstantiable
+    throw exception if enumeration is not an object $notObject
+  """
+
+  def successStringMapping = {
+    val cfg = ConfigFactory.parseString("myValue = SECOND")
+    implicit val classTag = ClassTag[StringValueEnum.type](StringValueEnum.getClass)
+    enumerationValueReader[StringValueEnum.type].read(cfg, "myValue") must be equalTo StringValueEnum.second
+  }
+
+  def successIntMapping = {
+    val cfg = ConfigFactory.parseString("myValue = second")
+    implicit val classTag = ClassTag[IntValueEnum.type](IntValueEnum.getClass)
+    enumerationValueReader[IntValueEnum.type].read(cfg, "myValue") must be equalTo IntValueEnum.second
+  }
+
+  def invalidMapping = {
+    val cfg = ConfigFactory.parseString("myValue = fourth")
+    implicit val classTag = ClassTag[StringValueEnum.type](StringValueEnum.getClass)
+    enumerationValueReader[StringValueEnum.type].read(cfg, "myValue") must throwA[ConfigException.BadValue]
+  }
+
+  def notInstantiable = {
+    val cfg = ConfigFactory.parseString("myValue = fourth")
+    implicit val classTag = ClassTag[InnerEnum.type](InnerEnum.getClass)
+    enumerationValueReader[InnerEnum.type].read(cfg, "myValue") must throwA[ConfigException.Generic]
+  }
+
+  def notObject = {
+    val cfg = ConfigFactory.parseString("myValue = fourth")
+    implicit val classTag = ClassTag[NotObject](classOf[NotObject])
+    enumerationValueReader[NotObject].read(cfg, "myValue") must throwA[ConfigException.Generic]
+  }
+
+  object InnerEnum extends Enumeration
+}
+
+object EnumerationReadersSpec {
+
+  object StringValueEnum extends Enumeration {
+    val first = Value("FIRST")
+    val second = Value("SECOND")
+    val third = Value("THIRD")
+  }
+
+  object IntValueEnum extends Enumeration {
+    val first, second, third = Value
+  }
+
+  class NotObject extends Enumeration
+}


### PR DESCRIPTION
This pull request adds the possibility to convert a config value to Scala's Enumeration type.

If I have the following enum:
```scala
object Country extends Enumeration {
  val DE = Value("DE")
  val IT = Value("IT")
  val NL = Value("NL")
  val US = Value("US")
  val GB = Value("GB")
}
```

I can define a config like:
```scala
countries = [DE, US, GB]
```

And then I get:
```scala
val countries = config.as[Seq[Country.Value]]("countries")
println(countries) // Seq(Country.DE, Country.US, Country.GB)
```